### PR TITLE
moved import sys before import tarfile

### DIFF
--- a/data_managers/data_manager_tiberius/data_manager/data_manager_tiberius.py
+++ b/data_managers/data_manager_tiberius/data_manager/data_manager_tiberius.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 
+import sys
 import argparse
 import json
 import os
 import shutil
 import tarfile
-import sys
 import tempfile
 from pathlib import Path
 


### PR DESCRIPTION
Planemo raised an issue on the order of import sys and import tarfile. The import sys should be before import tarfile

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
